### PR TITLE
inspect-cluster observes `-n {namespace}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ your $GOBIN by running `make install` or use it directly as `./kubectl-psachecke
 
 Returns the restrictive level for workloads present in the files specified by the `-f` flag (can be set multiple times).
 
-`./kubectl-psachecker inspect-cluster [--updates-only]`
+`./kubectl-psachecker inspect-cluster [-n namespace] [--updates-only]`
 
-Returns the restrictive level for all the namespaces in the cluster.
+Returns the restrictive level for [the selected namespace or] all namespaces in the cluster.
 
 ## The state of this repository
 

--- a/pkg/clusterinspect/options.go
+++ b/pkg/clusterinspect/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -50,7 +51,11 @@ func (o *ClusterInspectOptions) Run(ctx context.Context) (*admission.OrderedStri
 		return nil, fmt.Errorf("failed to set up admission: %w", err)
 	}
 
-	namespacesList, err := o.kubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	listOpts := metav1.ListOptions{}
+	if o.clientConfigOptions.Namespace != nil && *o.clientConfigOptions.Namespace != "" {
+		listOpts.FieldSelector = fields.OneTermEqualSelector("metadata.name", *o.clientConfigOptions.Namespace).String()
+	}
+	namespacesList, err := o.kubeClient.CoreV1().Namespaces().List(ctx, listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list namespaces: %w", err)
 	}


### PR DESCRIPTION
Add handling for `-n {namespace}` for `kubectl-psachecker inspect-cluster`